### PR TITLE
Fix multi-instance / re-run races between Renderer and AutkMap

### DIFF
--- a/autk-map/src/map.ts
+++ b/autk-map/src/map.ts
@@ -114,6 +114,8 @@ export class AutkMap {
     protected _animationFrameId: number | null = null;
     /** Indicates whether this map instance has been destroyed. */
     protected _isDestroyed: boolean = false;
+    /** Set after the first render-loop error to deduplicate repeated frame failures. */
+    protected _renderErrorLogged: boolean = false;
 
     /**
      * Creates an AutkMap instance bound to a canvas element.
@@ -817,6 +819,17 @@ export class AutkMap {
      * @returns Nothing. Rendering commands are recorded and submitted to the GPU.
      */
     private render() {
+        try {
+            this._renderFrame();
+        } catch (error) {
+            if (!this._renderErrorLogged) {
+                console.warn('AutkMap render skipped:', error);
+                this._renderErrorLogged = true;
+            }
+        }
+    }
+
+    private _renderFrame() {
         this._camera.update();
         const activePickingLayer = this.activePickingLayer;
         const pendingPick = activePickingLayer

--- a/autk-map/src/renderer.ts
+++ b/autk-map/src/renderer.ts
@@ -395,7 +395,9 @@ export class Renderer {
     /**
      * Starts the main render pass by clearing configured attachments.
      *
-     * @throws Never throws. Silently returns when not initialized.
+     * @throws Never throws. Silently returns when not initialized or when the
+     * canvas context has been transiently unconfigured (e.g. by a sibling
+     * renderer's destroy/recreate cycle in a multi-instance setup).
      */
     start(): void {
         if (!this._isInitialized) {
@@ -407,9 +409,16 @@ export class Renderer {
             return;
         }
 
+        let currentTextureView: GPUTextureView;
+        try {
+            currentTextureView = this._context.getCurrentTexture().createView();
+        } catch {
+            return;
+        }
+
         // Configure the frame buffer
         this._frameBuffer.loadOp = 'clear';
-        this._frameBuffer.resolveTarget = this._context.getCurrentTexture().createView();
+        this._frameBuffer.resolveTarget = currentTextureView;
         const sky = MapStyle.getColor('background');
         this._frameBuffer.clearValue = { r: sky.r / 255, g: sky.g / 255, b: sky.b / 255, a: 1 };
 

--- a/autk-map/src/renderer.ts
+++ b/autk-map/src/renderer.ts
@@ -335,10 +335,14 @@ export class Renderer {
             return;
         }
 
-        this._multisampleTexture?.destroy();
+        let colorTextureView: GPUTextureView;
+        try {
+            colorTextureView = this._context.getCurrentTexture().createView();
+        } catch {
+            return;
+        }
 
-        const colorTexture = this._context.getCurrentTexture();
-        const colorTextureView = colorTexture.createView();
+        this._multisampleTexture?.destroy();
 
         const multiSampleDesc: GPUTextureDescriptor = {
             size: [this._pixelWidth, this._pixelHeight],

--- a/autk-map/src/renderer.ts
+++ b/autk-map/src/renderer.ts
@@ -25,6 +25,7 @@ import { MapStyle } from './map-style';
 export class Renderer {
     private static readonly PICK_READBACK_BYTES_PER_ROW = 256;
     private static readonly PICK_READBACK_BUFFER_COUNT = 2;
+    private static _sharedDevicePromise: Promise<GPUDevice | null> | null = null;
     /** HTML canvas used as the backing render surface. */
     protected _canvas: HTMLCanvasElement;
 
@@ -210,12 +211,21 @@ export class Renderer {
 
             this._canvasFormat = entry.getPreferredCanvasFormat();
 
-            const adapter = await entry.requestAdapter();
-            if (adapter === null) {
+            if (!Renderer._sharedDevicePromise) {
+                Renderer._sharedDevicePromise = (async () => {
+                    const adapter = await entry.requestAdapter();
+                    if (adapter === null) return null;
+                    return adapter.requestDevice();
+                })();
+            }
+
+            const device = await Renderer._sharedDevicePromise;
+            if (device === null) {
+                Renderer._sharedDevicePromise = null;
                 return false;
             }
 
-            this._device = await adapter.requestDevice();
+            this._device = device;
         } catch (e) {
             console.error(e);
             return false;

--- a/autk-map/src/renderer.ts
+++ b/autk-map/src/renderer.ts
@@ -591,6 +591,13 @@ export class Renderer {
      * @throws Never throws.
      */
     destroy(): void {
+        // Mark uninitialized first so that any tick that races with destroy()
+        // (e.g. an in-flight animation frame from a sibling renderer that
+        // shares the canvas's GPUCanvasContext) sees `_isInitialized === false`
+        // and bails out of `start()` / `beginMainRenderPass()` before touching
+        // the resources we are about to release below.
+        this._isInitialized = false;
+
         this._multisampleTexture?.destroy();
         this._depthTexture?.destroy();
         this._pickingTexture?.destroy();
@@ -599,7 +606,6 @@ export class Renderer {
         this._context?.unconfigure();
 
         this._commandEncoder = null;
-        this._isInitialized = false;
     }
 
     /** Ensures a command encoder exists for the current frame. */


### PR DESCRIPTION
Two `AutkMap` instances on the same page can interleave each other's frames and destroy cycles, producing two distinct issues:

- **Uncaught `DOMException: GPUCanvasContext.getCurrentTexture: Canvas not configured`** when one renderer's `destroy()` overlaps with another's still-running animation-frame loop. The sibling's `start()` / `beginMainRenderPass()` / `configureFrameBuffer()` calls land on a transiently unconfigured canvas.
- **`Device of TextureView doesn't match Device` WebGPU validation errors** when module-level GPU resources created by one instance get reused on another instance's distinct `GPUDevice`.

Five small commits, each addressing one part:

- **`9f16cf7`** `fix(renderer): silently skip frame when canvas is unconfigured in start()` — wraps `getCurrentTexture()` in try/catch and bails. Preserves the documented "never throws" contract; the success path is unchanged.
- **`9d0e26f`** `fix(renderer): mark uninitialized before unconfigure in destroy()` — sets `_isInitialized = false` first so a tick racing with `destroy()` bails at the existing initialization guards instead of touching half-released resources.
- **`ad02eea`** `fix(renderer): bail in configureFrameBuffer when getCurrentTexture throws` — same race as `start()`; covers the `init()` / `resize()` paths the per-frame catch in `AutkMap.render()` can't reach. Acquires the new view first so a transient failure leaves the previous multisample texture intact.
- **`22558c9`** `fix(renderer): share a single GPUDevice across all instances` — caches the `requestDevice()` promise on the class so every `Renderer` reuses the same logical device. Eliminates the cross-device texture mismatches.
- **`a7b0a97`** `fix(map): catch frame-level errors in render() to avoid uncaught DOMException` — wraps the per-frame body in try/catch and logs once per `AutkMap` instance, so any leftover transient throw becomes a single warning instead of an uncaught exception.

**Reproducer**: two `AutkMap` instances on separate canvases, one calls `draw()` and is left running, the other repeatedly does `destroy()` + `new AutkMap(...)` + `init()` + `draw()`. Without these fixes, the first map crashes after one or two cycles; with them, the only visible signal is at most one console warning per affected map.
